### PR TITLE
[Fix] comma separator 

### DIFF
--- a/char_statistics_analyzer.py
+++ b/char_statistics_analyzer.py
@@ -10,7 +10,9 @@ config = {
         " ": "[space]",
         "\n": "[newline]",
         "\t": "[tab]",
-        "\b": "[backspace]"
+        "\b": "[backspace]",
+        ",": "[comma]",
+        ';': "[semicolon]"
     }
 }
 


### PR DESCRIPTION
Inserting characters like `,` or `;` into a csv report results in alignment errors in the csv report.

Added names for `,` and `;` as `comma` and `semicolon`